### PR TITLE
impl Stream and remove the "eager retry" logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["asynchronous", "concurrency"]
 
 [dependencies]
 futures-task = "0.3"
+futures-core = "0.3"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,14 @@ repository = "https://github.com/jonhoo/strawpoll.git"
 keywords = ["futures", "tokio"]
 categories = ["asynchronous", "concurrency"]
 
+[features]
+stream = ["futures-core"]
+
 [dependencies]
 futures-task = "0.3"
-futures-core = "0.3"
+futures-core = { version = "0.3", optional = true }
 
 [dev-dependencies]
 tokio-test = "0.4"
 tokio = { version = "1", features = ["sync"] }
+tokio-stream = "0.1.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ futures-core = { version = "0.3", optional = true }
 [dev-dependencies]
 tokio-test = "0.4"
 tokio = { version = "1", features = ["sync"] }
-tokio-stream = "0.1.9"
+tokio-stream = "0.1.11"
+async-stream = "0.3.3" # TODO: remove once tokio-test v0.4.3 is released
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ categories = ["asynchronous", "concurrency"]
 futures-task = "0.3"
 
 [dev-dependencies]
-tokio-test = "0.2"
-tokio = { version = "0.2", features = ["sync"] }
+tokio-test = "0.4"
+tokio = { version = "1", features = ["sync"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,7 @@ futures-core = { version = "0.3", optional = true }
 tokio-test = "0.4"
 tokio = { version = "1", features = ["sync"] }
 tokio-stream = "0.1.9"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@
     missing_docs,
     missing_debug_implementations,
     unreachable_pub,
-    rustdoc::broken_intra_doc_links
+    broken_intra_doc_links
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
@@ -160,7 +160,7 @@ impl<F> Strawpoll<F> {
         // reached this point unless F: Unpin.
         let mut fpin = unsafe { Pin::new_unchecked(&mut this.inner) };
         let wref = futures_task::waker_ref(waker);
-        let mut cx = Context::from_waker(&*wref);
+        let mut cx = Context::from_waker(&wref);
 
         #[cfg(test)]
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,10 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use std::sync::{
-    atomic::{AtomicBool, Ordering::SeqCst},
+    atomic::{
+        AtomicBool,
+        Ordering::{Relaxed, SeqCst},
+    },
     Arc,
 };
 use std::{
@@ -145,7 +148,7 @@ impl<F> Strawpoll<F> {
 
         let was_woken = waker
             .awoken
-            .compare_exchange(true, false, SeqCst, SeqCst)
+            .compare_exchange(true, false, SeqCst, Relaxed)
             .unwrap_or_else(|f| f);
 
         if !this.was_ready && !was_woken {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,8 @@ impl<F> Strawpoll<F> {
             this.npolls += 1;
         }
 
+        // `poll_fn` can call `wake()` immediately and, hence, `awoken` can be changed here.
+        // However, we doesn't touch `awoken` until the next polling, so it cannot cause races.
         let poll = poll_fn(fpin.as_mut(), &mut cx);
 
         if poll.is_ready() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,8 @@ impl<F> Strawpoll<F> {
         }
 
         // `poll_fn` can call `wake()` immediately and, hence, `awoken` can be changed here.
-        // However, we doesn't touch `awoken` until the next polling, so it cannot cause races.
+        // However, by the `Future::poll` contract, it must have called `.wake`, which means
+        // we've called `wake` on _our_ waker, which means we'll be polled again later.
         let poll = poll_fn(fpin.as_mut(), &mut cx);
 
         if poll.is_ready() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,9 @@
 //! // now there _was_ a notify, so the inner poll _should_ be called
 //! assert_eq!(rx.npolls, 2);
 //! ```
+//!
+//! # Feature flags
+//! * `stream`: Implements `futures::Stream` trait for [`Strawpoll`].
 #![warn(rust_2018_idioms)]
 #![deny(
     missing_docs,
@@ -73,6 +76,7 @@
     unreachable_pub,
     rustdoc::broken_intra_doc_links
 )]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use std::sync::{
     atomic::{AtomicBool, Ordering::SeqCst},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,6 +292,23 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "stream")]
+    #[test]
+    fn it_propagates_size_hint() {
+        struct SomeStream;
+        impl Stream for SomeStream {
+            type Item = ();
+            fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+                unreachable!();
+            }
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                (42, Some(43))
+            }
+        }
+
+        assert_eq!(Strawpoll::new(SomeStream).size_hint(), (42, Some(43)));
+    }
+
     #[test]
     fn multi_ready() {
         let (tx, rx) = mpsc::unbounded_channel();


### PR DESCRIPTION
* Added a `Stream` instance.
* Replaced deprecated lints and methods.
* Removed repolling on `Pending`. It's a controversial change, but I don't understand why the lib contains that logic. Firstly, it's a pretty rare situation, but it adds extra CAS on every `Pending`. Secondly, it doesn't seem to be the library's responsibility (and It breaks our tests (WS pool with tricky logic)).